### PR TITLE
Add Chat button on content pages to discuss with page as context

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ AI works in the background to help find, organise, and connect information acros
 - **Chats** — ask questions, AI searches authentic sources with query reformulation
 - **Notes** — save reflections, bookmarks from any content page
 - **Save anything** — every content page has a Save button that creates a note with a link back
+- **Chat about anything** — every content page also has a Chat button that opens a new conversation pre-loaded with what you're reading, so you can ask questions without copying text
 - **Public/private** — content is private by default, share with a toggle
 - **PWA** — installable on mobile/desktop
 - **User accounts** — email/password or Google OAuth, admin/user roles

--- a/html/adhkar.html
+++ b/html/adhkar.html
@@ -69,13 +69,28 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="adhkar-category">{{index . "Category"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "Title"}}">
-                    <input type="hidden" name="content" value="/adhkar/{{index . "Slug"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Title"}}">
+                        <input type="hidden" name="content" value="/adhkar/{{index . "Slug"}}
 
 {{truncate (index . "Translation") 200}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Title"}}">
+                        <input type="hidden" name="context" value="Adhkar — {{index . "Category"}} — {{index . "Title"}} (/adhkar/{{index . "Slug"}}){{if index . "Arabic"}}
+
+Arabic: {{index . "Arabic"}}{{end}}{{if index . "Transliteration"}}
+
+Transliteration: {{index . "Transliteration"}}{{end}}{{if index . "Translation"}}
+
+Translation: {{index . "Translation"}}{{end}}{{if index . "Benefits"}}
+
+Benefits: {{index . "Benefits"}}{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
 
             <h2>{{index . "Title"}}</h2>

--- a/html/arabic.html
+++ b/html/arabic.html
@@ -87,13 +87,23 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 {{if index . "Type"}}<span class="aw-type-tag">{{index . "Type"}}</span>{{else}}<span></span>{{end}}
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "Arabic"}} ({{index . "Transliteration"}}) — {{index . "English"}}">
-                    <input type="hidden" name="content" value="/arabic/{{index . "ID"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Arabic"}} ({{index . "Transliteration"}}) — {{index . "English"}}">
+                        <input type="hidden" name="content" value="/arabic/{{index . "ID"}}
 
 {{index . "Arabic"}} — {{index . "English"}} (appears {{index . "Frequency"}} times in the Quran)">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="Arabic word — {{index . "Transliteration"}}">
+                        <input type="hidden" name="context" value="Quranic Arabic vocabulary (/arabic/{{index . "ID"}})
+
+{{index . "Arabic"}} ({{index . "Transliteration"}}) — {{index . "English"}}
+Appears {{index . "Frequency"}} times in the Quran.">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
 
             <div class="aw-main-arabic">{{index . "Arabic"}}</div>

--- a/html/ghazali.html
+++ b/html/ghazali.html
@@ -38,13 +38,24 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="gh-volume" style="margin-bottom:0;">{{index . "VolumeTitle"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "Chapter"}}">
-                    <input type="hidden" name="content" value="/ghazali/{{index . "Slug"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Chapter"}}">
+                        <input type="hidden" name="content" value="/ghazali/{{index . "Slug"}}
 
 {{truncate (index . "Content") 200}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Chapter"}}">
+                        <input type="hidden" name="context" value="Ghazali, Ihya Ulum al-Din — {{index . "VolumeTitle"}} (/ghazali/{{index . "Slug"}})
+
+{{index . "Chapter"}}
+
+{{index . "Content"}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
             <h2 class="gh-chapter">{{index . "Chapter"}}</h2>
             <div class="gh-content">{{paragraphs (index . "Content")}}</div>

--- a/html/hadith.html
+++ b/html/hadith.html
@@ -54,13 +54,26 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="hadith-book" style="margin-bottom:0;">{{index . "Book"}} &mdash; Hadith {{index . "Number"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "Book"}} - {{index . "Narrator"}}">
-                    <input type="hidden" name="content" value="/hadith/{{index . "Number"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Book"}} - {{index . "Narrator"}}">
+                        <input type="hidden" name="content" value="/hadith/{{index . "Number"}}
 
 {{truncate (index . "Text") 200}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Book"}} - Hadith {{index . "Number"}}">
+                        <input type="hidden" name="context" value="{{index . "Book"}} — Hadith {{index . "Number"}} (/hadith/{{index . "Number"}})
+{{if index . "Narrator"}}
+{{index . "Narrator"}}{{end}}
+
+{{index . "Text"}}{{if index . "Arabic"}}
+
+Arabic: {{index . "Arabic"}}{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
             <h2>{{index . "Book"}} — Hadith {{index . "Number"}}</h2>
             {{if index . "Narrator"}}

--- a/html/home.html
+++ b/html/home.html
@@ -151,6 +151,11 @@
                             <input type="hidden" name="content" value="{{index .DailyContent "Verse"}}">
                             <button type="submit" class="daily-btn">Save</button>
                         </form>
+                        <form method="POST" action="/chat/new" style="display:inline;">
+                            <input type="hidden" name="title" value="Quran Verse">
+                            <input type="hidden" name="context" value="Quran verse: {{index .DailyContent "Verse"}}">
+                            <button type="submit" class="daily-btn">Chat</button>
+                        </form>
                     </div>
                 </div>
                 {{end}}
@@ -166,6 +171,11 @@
                             <input type="hidden" name="content" value="{{index .DailyContent "Hadith"}}">
                             <button type="submit" class="daily-btn">Save</button>
                         </form>
+                        <form method="POST" action="/chat/new" style="display:inline;">
+                            <input type="hidden" name="title" value="Hadith">
+                            <input type="hidden" name="context" value="Hadith: {{index .DailyContent "Hadith"}}">
+                            <button type="submit" class="daily-btn">Chat</button>
+                        </form>
                     </div>
                 </div>
                 {{end}}
@@ -180,6 +190,11 @@
                             <input type="hidden" name="title" value="Name of Allah">
                             <input type="hidden" name="content" value="{{index .DailyContent "NameOfAllah"}}">
                             <button type="submit" class="daily-btn">Save</button>
+                        </form>
+                        <form method="POST" action="/chat/new" style="display:inline;">
+                            <input type="hidden" name="title" value="Name of Allah">
+                            <input type="hidden" name="context" value="Name of Allah: {{index .DailyContent "NameOfAllah"}}">
+                            <button type="submit" class="daily-btn">Chat</button>
                         </form>
                     </div>
                 </div>

--- a/html/islamqa.html
+++ b/html/islamqa.html
@@ -54,13 +54,24 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="qa-category" style="margin-bottom:0;">{{index . "Category"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "Question"}}">
-                    <input type="hidden" name="content" value="/islamqa/{{index . "Slug"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Question"}}">
+                        <input type="hidden" name="content" value="/islamqa/{{index . "Slug"}}
 
 {{truncate (index . "Answer") 200}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "Question"}}">
+                        <input type="hidden" name="context" value="IslamQA — {{index . "Category"}} (/islamqa/{{index . "Slug"}})
+
+Question: {{index . "Question"}}
+
+Answer: {{index . "Answer"}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
 
             <div class="qa-section-label">Question</div>

--- a/html/name.html
+++ b/html/name.html
@@ -69,13 +69,27 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="name-number" style="margin-bottom:0;">#{{index . "Number"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{index . "English"}} — {{index . "Meaning"}}">
-                    <input type="hidden" name="content" value="/names/{{index . "Number"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{index . "English"}} — {{index . "Meaning"}}">
+                        <input type="hidden" name="content" value="/names/{{index . "Number"}}
 
 {{index . "Description"}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="Name of Allah — {{index . "English"}}">
+                        <input type="hidden" name="context" value="Name of Allah #{{index . "Number"}} (/names/{{index . "Number"}})
+{{if index . "Arabic"}}
+{{index . "Arabic"}}{{end}}
+{{index . "English"}}{{if index . "Meaning"}} — {{index . "Meaning"}}{{end}}{{if index . "Description"}}
+
+{{index . "Description"}}{{end}}{{if index . "Summary"}}
+
+{{index . "Summary"}}{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
             {{if index . "Arabic"}}
             <div class="name-arabic">{{index . "Arabic"}}</div>

--- a/html/quran.html
+++ b/html/quran.html
@@ -70,13 +70,26 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="quran-ref" style="margin-bottom:0;">Surah {{index . "ChapterName"}} &mdash; {{index . "Chapter"}}:{{index . "Verse"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="Quran {{index . "ChapterName"}} {{index . "Chapter"}}:{{index . "Verse"}}">
-                    <input type="hidden" name="content" value="/quran/{{index . "Chapter"}}/{{index . "Verse"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="Quran {{index . "ChapterName"}} {{index . "Chapter"}}:{{index . "Verse"}}">
+                        <input type="hidden" name="content" value="/quran/{{index . "Chapter"}}/{{index . "Verse"}}
 
 {{index . "Text"}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="Quran {{index . "ChapterName"}} {{index . "Chapter"}}:{{index . "Verse"}}">
+                        <input type="hidden" name="context" value="Quran — Surah {{index . "ChapterName"}} — {{index . "Chapter"}}:{{index . "Verse"}} (/quran/{{index . "Chapter"}}/{{index . "Verse"}}){{if index . "Arabic"}}
+
+Arabic: {{index . "Arabic"}}{{end}}
+
+Translation: {{index . "Text"}}{{if index . "Commentary"}}
+
+Commentary: {{index . "Commentary"}}{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
             {{if index . "Arabic"}}
             <div class="quran-arabic">{{index . "Arabic"}}</div>

--- a/html/salihin.html
+++ b/html/salihin.html
@@ -54,13 +54,26 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
                 <span class="riyad-book" style="margin-bottom:0;">{{index . "Book"}} &mdash; Hadith {{index . "Number"}}</span>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="Riyad us-Salihin - {{index . "Book"}} - Hadith {{index . "Number"}}">
-                    <input type="hidden" name="content" value="/salihin/{{index . "Number"}}
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="Riyad us-Salihin - {{index . "Book"}} - Hadith {{index . "Number"}}">
+                        <input type="hidden" name="content" value="/salihin/{{index . "Number"}}
 
 {{truncate (index . "Text") 200}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="Riyad us-Salihin - {{index . "Book"}} - Hadith {{index . "Number"}}">
+                        <input type="hidden" name="context" value="Riyad us-Salihin — {{index . "Book"}} — Hadith {{index . "Number"}} (/salihin/{{index . "Number"}})
+{{if index . "Narrator"}}
+{{index . "Narrator"}}{{end}}
+
+{{index . "Text"}}{{if index . "Arabic"}}
+
+Arabic: {{index . "Arabic"}}{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
             <h2>{{index . "Book"}} — Hadith {{index . "Number"}}</h2>
             {{if index . "Narrator"}}

--- a/html/stories.html
+++ b/html/stories.html
@@ -50,11 +50,22 @@
         <main class="app-content">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
                 <h2 style="margin-bottom:0;">{{.Name}}</h2>
-                <form method="POST" action="/notes/add" style="display:inline;">
-                    <input type="hidden" name="title" value="{{.Name}} ({{.Arabic}}) — {{.Title}}">
-                    <input type="hidden" name="content" value="/stories/{{.Slug}}">
-                    <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
-                </form>
+                <div style="display:flex; gap:6px;">
+                    <form method="POST" action="/notes/add" style="display:inline;">
+                        <input type="hidden" name="title" value="{{.Name}} ({{.Arabic}}) — {{.Title}}">
+                        <input type="hidden" name="content" value="/stories/{{.Slug}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Save</button>
+                    </form>
+                    <form method="POST" action="/chat/new" style="display:inline;">
+                        <input type="hidden" name="title" value="Story of {{.Name}}">
+                        <input type="hidden" name="context" value="Story of the Prophet {{.Name}} ({{.Arabic}}) — {{.Title}} (/stories/{{.Slug}})
+
+{{range .Sections}}{{.Narrative}}
+
+{{end}}">
+                        <button type="submit" style="font-size:12px; padding:4px 10px; border:1px solid #ddd; border-radius:4px; background:#fff; color:#666; cursor:pointer;">Chat</button>
+                    </form>
+                </div>
             </div>
 
             <div class="prophet-arabic">{{.Arabic}}</div>

--- a/main.go
+++ b/main.go
@@ -1968,13 +1968,39 @@ func handleNewChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := getUserID(r)
-	id, err := db.CreateConversation("New conversation", userID)
+
+	// Optional page context: the "Chat" button on content pages posts a title
+	// and the content being read, so the conversation opens pre-loaded with
+	// whatever the user was looking at as context.
+	title := strings.TrimSpace(r.FormValue("title"))
+	pageContext := strings.TrimSpace(r.FormValue("context"))
+
+	convTitle := "New conversation"
+	if title != "" {
+		convTitle = truncateRunes(title, 50)
+	}
+
+	id, err := db.CreateConversation(convTitle, userID)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
 
+	if pageContext != "" {
+		db.AddMessage(id, "context", pageContext)
+	}
+
 	http.Redirect(w, r, fmt.Sprintf("/chat/%d", id), http.StatusSeeOther)
+}
+
+// truncateRunes shortens a string to at most n runes, appending an ellipsis if
+// it was cut. Rune-safe so multi-byte titles (e.g. Arabic) aren't split.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "..."
 }
 
 func handleSendMessage(w http.ResponseWriter, r *http.Request) {
@@ -2462,6 +2488,47 @@ type ToolUsage struct {
 	Output string
 }
 
+// buildAPIMessages converts stored conversation messages into the message
+// list sent to the Anthropic API. "context" and "tool" messages are replayed
+// as assistant turns so the model can reference them. Any context messages
+// that appear before the first user message (e.g. the page content a chat was
+// opened from) are folded into the system prompt instead, since the API
+// requires the first message to use the user role. It returns the API messages
+// and any text to append to the system prompt.
+func buildAPIMessages(messages []db.Message) ([]map[string]interface{}, string) {
+	var apiMessages []map[string]interface{}
+	var leadingContext []string
+	seenUser := false
+	for _, m := range messages {
+		if m.Role == "system" {
+			continue
+		}
+		// Page context loaded before the conversation starts goes into the
+		// system prompt rather than the message list.
+		if !seenUser && m.Role == "context" {
+			leadingContext = append(leadingContext, m.Content)
+			continue
+		}
+		if m.Role == "user" {
+			seenUser = true
+		}
+		role := m.Role
+		if role == "context" || role == "tool" {
+			role = "assistant"
+		}
+		apiMessages = append(apiMessages, map[string]interface{}{
+			"role":    role,
+			"content": m.Content,
+		})
+	}
+
+	var contextPrompt string
+	if len(leadingContext) > 0 {
+		contextPrompt = "\n\nThe user opened this chat while reading the following content and is likely asking about it. Use it as the primary context for their questions:\n\n" + strings.Join(leadingContext, "\n\n")
+	}
+	return apiMessages, contextPrompt
+}
+
 func generateResponse(messages []db.Message, convID int64) (string, []ToolUsage, error) {
 	return generateResponseWithProgress(messages, convID, nil)
 }
@@ -2483,20 +2550,8 @@ func generateResponseWithProgress(messages []db.Message, convID int64, onTool fu
 	}
 
 	// Build messages for API
-	var apiMessages []map[string]interface{}
-	for _, m := range messages {
-		if m.Role == "system" {
-			continue
-		}
-		role := m.Role
-		if role == "context" || role == "tool" {
-			role = "assistant"
-		}
-		apiMessages = append(apiMessages, map[string]interface{}{
-			"role":    role,
-			"content": m.Content,
-		})
-	}
+	apiMessages, contextPrompt := buildAPIMessages(messages)
+	fullSystemPrompt += contextPrompt
 
 	// Tool loop - keep calling until we get a final response
 	for i := 0; i < 10; i++ { // Max 10 tool calls
@@ -2591,20 +2646,8 @@ func generateResponseStreaming(messages []db.Message, convID int64, onText func(
 		}
 	}
 
-	var apiMessages []map[string]interface{}
-	for _, m := range messages {
-		if m.Role == "system" {
-			continue
-		}
-		role := m.Role
-		if role == "context" || role == "tool" {
-			role = "assistant"
-		}
-		apiMessages = append(apiMessages, map[string]interface{}{
-			"role":    role,
-			"content": m.Content,
-		})
-	}
+	apiMessages, contextPrompt := buildAPIMessages(messages)
+	fullSystemPrompt += contextPrompt
 
 	for i := 0; i < 10; i++ {
 		result, textSoFar, err := callAnthropicStream(apiMessages, fullSystemPrompt, onText)


### PR DESCRIPTION
Every content page (Quran, Hadith, Riyad us-Salihin, Names of Allah, IslamQA, Ghazali, Adhkar, Arabic, Stories) and the home daily reminders now have a Chat button alongside Save. Clicking it opens a new conversation pre-loaded with the content you're reading, so you can ask questions without copying text.

- handleNewChat now accepts optional title + context form fields and stores the page content as a "context" message on the new conversation
- New buildAPIMessages helper folds leading context messages into the system prompt (the API requires the first message to be a user turn) and is shared by both generateResponse and generateResponseStreaming
- truncateRunes for rune-safe conversation titles

https://claude.ai/code/session_01RrNKnamBBxhV5rR5B26QCY