### PR TITLE
Fix Chat-from-page context not reaching the model

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -893,7 +893,7 @@ func GetMessages(convID int64) ([]Message, error) {
 		SELECT id, conversation_id, role, content, created_at
 		FROM messages
 		WHERE conversation_id = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`, convID)
 	if err != nil {
 		return nil, err
@@ -914,7 +914,7 @@ func GetMessagesAfter(convID, afterID int64) ([]Message, error) {
 		SELECT id, conversation_id, role, content, created_at
 		FROM messages
 		WHERE conversation_id = ? AND id > ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`, convID, afterID)
 	if err != nil {
 		return nil, err

--- a/html/chat.html
+++ b/html/chat.html
@@ -84,7 +84,7 @@
 
             {{if .Messages}}
             {{range .Messages}}
-            {{if or (eq .Role "tool") (eq .Role "context")}}{{else}}
+            {{if or (eq .Role "tool") (eq .Role "context") (eq .Role "system")}}{{else}}
             <div class="message {{.Role}}">
                 <div class="message-role">{{if eq .Role "user"}}{{$.UserName}}{{else}}Assistant{{end}} <span class="time" data-time="{{.CreatedAt.Unix}}">{{formatTime .CreatedAt}}</span></div>
                 <div class="message-content{{if eq .Role "assistant"}} markdown{{end}}">{{.Content}}</div>

--- a/main.go
+++ b/main.go
@@ -1987,7 +1987,10 @@ func handleNewChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if pageContext != "" {
-		db.AddMessage(id, "context", pageContext)
+		// Stored as a "system" message: it passes the role CHECK constraint
+		// (unlike "context") and buildAPIMessages folds it into the system
+		// prompt, so the conversation still opens with a real user turn.
+		db.AddMessage(id, "system", pageContext)
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("/chat/%d", id), http.StatusSeeOther)
@@ -2497,16 +2500,26 @@ type ToolUsage struct {
 // and any text to append to the system prompt.
 func buildAPIMessages(messages []db.Message) ([]map[string]interface{}, string) {
 	var apiMessages []map[string]interface{}
-	var leadingContext []string
+	var pageContext []string
 	seenUser := false
 	for _, m := range messages {
+		// "system" messages carry the page/seed context a chat was opened
+		// with (e.g. the verse or hadith the user clicked "Chat" on). They are
+		// folded into the system prompt regardless of position, so the message
+		// list always begins with a real user turn and never ends on a stray
+		// assistant turn.
 		if m.Role == "system" {
+			if strings.TrimSpace(m.Content) != "" {
+				pageContext = append(pageContext, m.Content)
+			}
 			continue
 		}
-		// Page context loaded before the conversation starts goes into the
-		// system prompt rather than the message list.
+		// Legacy: older databases allowed the "context" role for page context
+		// stored before the first user turn. Fold those in the same way.
 		if !seenUser && m.Role == "context" {
-			leadingContext = append(leadingContext, m.Content)
+			if strings.TrimSpace(m.Content) != "" {
+				pageContext = append(pageContext, m.Content)
+			}
 			continue
 		}
 		if m.Role == "user" {
@@ -2523,8 +2536,8 @@ func buildAPIMessages(messages []db.Message) ([]map[string]interface{}, string) 
 	}
 
 	var contextPrompt string
-	if len(leadingContext) > 0 {
-		contextPrompt = "\n\nThe user opened this chat while reading the following content and is likely asking about it. Use it as the primary context for their questions:\n\n" + strings.Join(leadingContext, "\n\n")
+	if len(pageContext) > 0 {
+		contextPrompt = "\n\nThe user opened this chat while reading the following content and is likely asking about it. Use it as the primary context for their questions:\n\n" + strings.Join(pageContext, "\n\n")
 	}
 	return apiMessages, contextPrompt
 }


### PR DESCRIPTION
The page context for the Chat button was stored with role "context", which the messages table CHECK constraint rejects (it only allows user/assistant/system) — so the context was silently dropped and never reached the model. Combined with the unstable message ordering, a chat opened from a page could send a malformed turn list, producing replies like "your message came through empty".

- Store page context as a "system" message (passes the CHECK constraint)
- buildAPIMessages folds all "system" messages into the system prompt regardless of position, so the turn list always starts with a real user message and never ends on a stray assistant turn
- Hide "system" messages in the chat view
- Order messages by (created_at, id) so same-second inserts stay in insertion order

https://claude.ai/code/session_01RrNKnamBBxhV5rR5B26QCY